### PR TITLE
Add Windows + Linux builds CI/CD

### DIFF
--- a/.github/workflows/ydms-build.yaml
+++ b/.github/workflows/ydms-build.yaml
@@ -35,3 +35,22 @@ jobs:
         with:
           name: ${{ env.distname }}
           path: ${{ env.builddir }}/**/*.so
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+
+      - name: Build solution
+        run: |
+          cmake -B build -S .
+          cmake --build build --config Release
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: rnnoise-windows
+          path: build/**/*.dll

--- a/.github/workflows/ydms-build.yaml
+++ b/.github/workflows/ydms-build.yaml
@@ -1,0 +1,37 @@
+name: "YDMS Build"
+
+on: [push]
+
+jobs:
+  build-linux:
+    strategy:
+      matrix:
+        osver: [ubuntu-latest, ubuntu-24.04-arm]
+
+    runs-on: ${{ matrix.osver }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set dist name
+        run: |
+          if ${{ matrix.osver == 'ubuntu-24.04-arm' }}; then
+            echo "distname=rnnoise-linux-arm" >> "$GITHUB_ENV"
+          else
+            echo "distname=rnnoise-linux" >> "$GITHUB_ENV"
+          fi
+      - name: Create build dirs
+        run: |
+          mkdir build
+          cd build
+          echo "builddir=$(pwd)" >> "$GITHUB_ENV"
+      - name: Build rnnoise Linux
+        working-directory: ${{ env.builddir }}
+        run: |
+          cmake -DCMAKE_BUILD_TYPE=Release ..
+          make -j4
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.distname }}
+          path: ${{ env.builddir }}/**/*.so

--- a/include/rnnoise.h
+++ b/include/rnnoise.h
@@ -115,5 +115,3 @@ RNNOISE_EXPORT void rnnoise_model_free(RNNModel *model);
 }
 #endif
 #endif
-
-#endif


### PR DESCRIPTION
This PR adds CI/CD to build the Windows and Linux releases.

Exports:
- `rnnoise-windows` for the Windows version
- `rnnoise-linux` for the Linux x64 version
- `rnnoise-linux-arm` for the Linux ARM version

Changes:
- Minor code change in `include/rnnoise.h` that removes an unmatched `#endif`

--- 

Proofs: https://github.com/jae1911/rnnoise-ydms/actions/runs/13095594840